### PR TITLE
update roles.yaml

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -17,6 +17,7 @@ rules:
       - secrets
       - replicationcontrollers
       - podtemplates
+      - serviceaccounts
     verbs:
       - create
       - delete


### PR DESCRIPTION
As mentioned in https://github.com/m88i/nexus-operator/pull/52 the operator will now create service accounts based on parameters or Custom Resource names, for that the operator role has to include service account resources.